### PR TITLE
Add WebGL shader hero to homepage

### DIFF
--- a/components/home/SuiteHero.jsx
+++ b/components/home/SuiteHero.jsx
@@ -2,6 +2,8 @@
 
 import { motion } from "framer-motion";
 import Link from "next/link";
+import { WebGLShader } from "@/components/ui/web-gl-shader";
+import { LiquidButton } from "@/components/ui/liquid-button";
 
 const fadeUp = (delay = 0) => ({
   initial: { opacity: 0, y: 20 },
@@ -46,106 +48,133 @@ const products = [
 
 export default function SuiteHero() {
   return (
-    <section className="bg-surface pt-[60px]">
-      <div className="max-w-content mx-auto px-6 lg:px-8 pt-20 pb-0 text-center">
+    <>
+      {/* ── Dark hero with WebGL shader ── */}
+      <section className="relative min-h-[88vh] flex items-center justify-center overflow-hidden pt-[60px]">
+        <WebGLShader />
 
-        {/* Eyebrow */}
-        <motion.div {...fadeUp(0)} className="mb-6 flex justify-center">
-          <span className="inline-flex items-center gap-2 font-mono text-[11px] font-medium uppercase tracking-widest text-wb bg-wb-light px-3 py-1.5 rounded-full">
-            <span className="w-1.5 h-1.5 rounded-full bg-wb" />
-            Free tools for every church
-          </span>
-        </motion.div>
+        {/* Subtle overlay to ensure text contrast */}
+        <div className="absolute inset-0 bg-dark/40 z-[1]" />
 
-        {/* Headline */}
-        <motion.h1
-          {...fadeUp(0.08)}
-          className="font-heading text-[clamp(46px,8vw,88px)] leading-[1.04] tracking-[-0.02em] text-ink text-balance mx-auto max-w-4xl mb-6"
-        >
-          Everything your worship{" "}
-          <em className="not-italic text-wb">team needs</em>
-        </motion.h1>
+        <div className="relative z-10 w-full max-w-content mx-auto px-6 lg:px-8 py-20">
+          {/* Double-border container — nod to the demo layout */}
+          <motion.div
+            initial={{ opacity: 0, y: 24 }}
+            animate={{ opacity: 1, y: 0 }}
+            transition={{ duration: 0.65, ease: [0.21, 0.47, 0.32, 0.98] }}
+            className="border border-white/10 p-1.5 max-w-3xl mx-auto"
+          >
+            <div className="border border-white/10 px-8 py-14 text-center">
 
-        {/* Sub */}
-        <motion.p
-          {...fadeUp(0.15)}
-          className="font-sans text-[18px] text-muted max-w-xl mx-auto mb-10 leading-relaxed"
-        >
-          Song management, team scheduling, and live presentation — built by
-          worship leaders, free forever.
-        </motion.p>
+              {/* Eyebrow */}
+              <motion.div {...fadeUp(0.08)} className="mb-7 flex justify-center">
+                <span className="inline-flex items-center gap-2 font-mono text-[11px] font-medium uppercase tracking-widest text-white/70 px-3 py-1.5">
+                  <span className="w-1.5 h-1.5 rounded-full bg-white/60" />
+                  Free tools for every church
+                </span>
+              </motion.div>
 
-        {/* CTAs */}
-        <motion.div
-          {...fadeUp(0.22)}
-          className="flex flex-col sm:flex-row gap-3 justify-center mb-10"
-        >
-          <Link href="#products" className="btn btn-primary btn-lg">
-            Explore the suite
-          </Link>
-          <Link href="/about" className="btn btn-ghost btn-lg">
-            Read our story
-          </Link>
-        </motion.div>
+              {/* Headline */}
+              <motion.h1
+                {...fadeUp(0.14)}
+                className="font-heading text-[clamp(42px,7vw,80px)] leading-[1.05] tracking-[-0.02em] text-white text-balance mx-auto max-w-2xl mb-6"
+              >
+                Everything your worship{" "}
+                <em className="not-italic text-white/70">team needs</em>
+              </motion.h1>
 
-        {/* Trust badges */}
-        <motion.div
-          {...fadeUp(0.28)}
-          className="flex flex-wrap items-center justify-center gap-x-6 gap-y-2 mb-16"
-        >
-          {trustBadges.map((badge) => (
-            <span key={badge} className="flex items-center gap-1.5 font-mono text-[11px] text-muted">
-              <span className="w-3.5 h-3.5 rounded-full bg-green-500 flex items-center justify-center text-white text-[8px] font-bold">✓</span>
-              {badge}
-            </span>
-          ))}
-        </motion.div>
+              {/* Subtitle */}
+              <motion.p
+                {...fadeUp(0.2)}
+                className="font-sans text-[17px] text-white/70 max-w-lg mx-auto mb-10 leading-relaxed"
+              >
+                Song management, team scheduling, and live presentation — built by
+                worship leaders, free forever.
+              </motion.p>
 
-        {/* Product cards — 3-column grid */}
-        <motion.div
-          initial={{ opacity: 0, y: 36 }}
-          animate={{ opacity: 1, y: 0 }}
-          transition={{ duration: 0.7, delay: 0.35, ease: [0.21, 0.47, 0.32, 0.98] }}
-          className="grid md:grid-cols-3 gap-5 pb-24 text-left"
-        >
-          {products.map((product) => (
-            <Link
-              key={product.id}
-              href={product.href}
-              className="card border-l-4 p-0 overflow-hidden hover:shadow-card-hover transition-shadow duration-200 group"
-              style={{ borderLeftColor: product.color }}
-            >
-              {/* Placeholder image */}
-              <div className={`${product.lightBg} aspect-[16/10] flex items-center justify-center border-b border-border`}>
-                <div className="text-center">
-                  <p className="font-mono text-[11px] font-medium uppercase tracking-wider" style={{ color: product.color }}>
-                    {product.name}
-                  </p>
-                  <p className="font-sans text-[13px] text-muted mt-1">
-                    {product.imageLabel}
-                  </p>
-                </div>
-              </div>
+              {/* CTAs */}
+              <motion.div
+                {...fadeUp(0.26)}
+                className="flex flex-col sm:flex-row gap-3 justify-center mb-10"
+              >
+                <Link href="#products">
+                  <LiquidButton size="lg" className="text-white border border-white/20">
+                    Explore the suite
+                  </LiquidButton>
+                </Link>
+                <Link href="/about">
+                  <LiquidButton size="lg" className="text-white/75 border border-white/15">
+                    Read our story
+                  </LiquidButton>
+                </Link>
+              </motion.div>
 
-              {/* Card body */}
-              <div className="p-5">
-                <div className="flex items-center gap-2 mb-2">
-                  <span className="w-2 h-2 rounded-full shrink-0" style={{ background: product.color }} />
-                  <span className="font-mono text-[12px] font-semibold tracking-tight" style={{ color: product.color }}>
-                    {product.name}
+              {/* Trust badges */}
+              <motion.div
+                {...fadeUp(0.32)}
+                className="flex flex-wrap items-center justify-center gap-x-6 gap-y-2"
+              >
+                {trustBadges.map((badge) => (
+                  <span key={badge} className="flex items-center gap-1.5 font-mono text-[11px] text-white/60">
+                    <span className="w-3.5 h-3.5 rounded-full bg-green-500/80 flex items-center justify-center text-white text-[8px] font-bold">✓</span>
+                    {badge}
                   </span>
+                ))}
+              </motion.div>
+
+            </div>
+          </motion.div>
+        </div>
+      </section>
+
+      {/* ── Product cards — light surface ── */}
+      <section id="products" className="bg-surface py-20">
+        <div className="max-w-content mx-auto px-6 lg:px-8">
+          <motion.div
+            initial={{ opacity: 0, y: 36 }}
+            animate={{ opacity: 1, y: 0 }}
+            transition={{ duration: 0.7, delay: 0.35, ease: [0.21, 0.47, 0.32, 0.98] }}
+            className="grid md:grid-cols-3 gap-5 text-left"
+          >
+            {products.map((product) => (
+              <Link
+                key={product.id}
+                href={product.href}
+                className="card border-l-4 p-0 overflow-hidden hover:shadow-card-hover transition-shadow duration-200 group"
+                style={{ borderLeftColor: product.color }}
+              >
+                {/* Placeholder image */}
+                <div className={`${product.lightBg} aspect-[16/10] flex items-center justify-center border-b border-border`}>
+                  <div className="text-center">
+                    <p className="font-mono text-[11px] font-medium uppercase tracking-wider" style={{ color: product.color }}>
+                      {product.name}
+                    </p>
+                    <p className="font-sans text-[13px] text-muted mt-1">
+                      {product.imageLabel}
+                    </p>
+                  </div>
                 </div>
-                <h3 className="font-sans font-semibold text-[17px] text-ink mb-2">
-                  {product.tagline}
-                </h3>
-                <p className="font-sans text-[14px] text-muted leading-relaxed">
-                  {product.description}
-                </p>
-              </div>
-            </Link>
-          ))}
-        </motion.div>
-      </div>
-    </section>
+
+                {/* Card body */}
+                <div className="p-5">
+                  <div className="flex items-center gap-2 mb-2">
+                    <span className="w-2 h-2 rounded-full shrink-0" style={{ background: product.color }} />
+                    <span className="font-mono text-[12px] font-semibold tracking-tight" style={{ color: product.color }}>
+                      {product.name}
+                    </span>
+                  </div>
+                  <h3 className="font-sans font-semibold text-[17px] text-ink mb-2">
+                    {product.tagline}
+                  </h3>
+                  <p className="font-sans text-[14px] text-muted leading-relaxed">
+                    {product.description}
+                  </p>
+                </div>
+              </Link>
+            ))}
+          </motion.div>
+        </div>
+      </section>
+    </>
   );
 }

--- a/components/ui/liquid-button.jsx
+++ b/components/ui/liquid-button.jsx
@@ -1,0 +1,97 @@
+"use client";
+
+function GlassFilter() {
+  return (
+    <svg className="hidden" aria-hidden="true">
+      <defs>
+        <filter
+          id="liquid-glass-filter"
+          x="0%"
+          y="0%"
+          width="100%"
+          height="100%"
+          colorInterpolationFilters="sRGB"
+        >
+          <feTurbulence
+            type="fractalNoise"
+            baseFrequency="0.05 0.05"
+            numOctaves="1"
+            seed="1"
+            result="turbulence"
+          />
+          <feGaussianBlur in="turbulence" stdDeviation="2" result="blurredNoise" />
+          <feDisplacementMap
+            in="SourceGraphic"
+            in2="blurredNoise"
+            scale="70"
+            xChannelSelector="R"
+            yChannelSelector="B"
+            result="displaced"
+          />
+          <feGaussianBlur in="displaced" stdDeviation="4" result="finalBlur" />
+          <feComposite in="finalBlur" in2="finalBlur" operator="over" />
+        </filter>
+      </defs>
+    </svg>
+  );
+}
+
+/**
+ * LiquidButton — glassmorphism button with SVG distortion filter.
+ * Designed for use on dark backgrounds (e.g. the WebGL shader hero).
+ *
+ * Props:
+ *   className  – extra Tailwind classes (e.g. text color, border)
+ *   children   – button label / content
+ *   size       – "sm" | "md" | "lg" (default: "md")
+ */
+export function LiquidButton({ children, className = "", size = "md", ...props }) {
+  const sizeClasses = {
+    sm: "h-9 px-5 text-sm",
+    md: "h-11 px-7 text-sm",
+    lg: "h-13 px-9 text-base",
+  };
+
+  return (
+    <button
+      className={[
+        "relative inline-flex items-center justify-center cursor-pointer",
+        "gap-2 whitespace-nowrap font-medium rounded-full",
+        "transition-[opacity,transform] duration-200",
+        "hover:opacity-90 active:scale-[0.97]",
+        sizeClasses[size] || sizeClasses.md,
+        className,
+      ].join(" ")}
+      {...props}
+    >
+      {/* Glass shadow ring */}
+      <div
+        className="absolute inset-0 rounded-full z-0 transition-all duration-200"
+        style={{
+          boxShadow: [
+            "0 0 6px rgba(0,0,0,0.03)",
+            "0 2px 6px rgba(0,0,0,0.08)",
+            "inset 3px 3px 0.5px -3.5px rgba(255,255,255,0.09)",
+            "inset -3px -3px 0.5px -3.5px rgba(255,255,255,0.85)",
+            "inset 1px 1px 1px -0.5px rgba(255,255,255,0.6)",
+            "inset -1px -1px 1px -0.5px rgba(255,255,255,0.6)",
+            "inset 0 0 6px 6px rgba(255,255,255,0.12)",
+            "inset 0 0 2px 2px rgba(255,255,255,0.06)",
+            "0 0 12px rgba(0,0,0,0.15)",
+          ].join(","),
+        }}
+      />
+
+      {/* Backdrop distortion layer */}
+      <div
+        className="absolute inset-0 isolate -z-10 overflow-hidden rounded-full"
+        style={{ backdropFilter: 'url("#liquid-glass-filter")' }}
+      />
+
+      {/* Label */}
+      <span className="relative z-10 pointer-events-none">{children}</span>
+
+      <GlassFilter />
+    </button>
+  );
+}

--- a/components/ui/web-gl-shader.jsx
+++ b/components/ui/web-gl-shader.jsx
@@ -1,0 +1,153 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+import * as THREE from "three";
+
+export function WebGLShader() {
+  const canvasRef = useRef(null);
+  const sceneRef = useRef({
+    scene: null,
+    camera: null,
+    renderer: null,
+    mesh: null,
+    uniforms: null,
+    animationId: null,
+  });
+
+  useEffect(() => {
+    if (!canvasRef.current) return;
+
+    const canvas = canvasRef.current;
+    const refs = sceneRef.current;
+
+    const vertexShader = `
+      attribute vec3 position;
+      void main() {
+        gl_Position = vec4(position, 1.0);
+      }
+    `;
+
+    // Brand-adapted fragment shader:
+    // Dark navy background with three overlapping waves in WB/PB/CB brand colors.
+    // Chromatic-aberration-style separation gives the waves an iridescent quality.
+    const fragmentShader = `
+      precision highp float;
+      uniform vec2 resolution;
+      uniform float time;
+      uniform float xScale;
+      uniform float yScale;
+      uniform float distortion;
+
+      void main() {
+        vec2 p = (gl_FragCoord.xy * 2.0 - resolution) / min(resolution.x, resolution.y);
+
+        float d = length(p) * distortion;
+
+        float rx = p.x * (1.0 + d);
+        float gx = p.x;
+        float bx = p.x * (1.0 - d);
+
+        // Softer wave brightness
+        float r = 0.035 / abs(p.y + sin((rx + time) * xScale) * yScale);
+        float g = 0.028 / abs(p.y + sin((gx + time) * xScale) * yScale);
+        float b = 0.022 / abs(p.y + sin((bx + time) * xScale) * yScale);
+
+        // Dark navy base: #080D18
+        vec3 bg = vec3(0.031, 0.051, 0.094);
+
+        // Per-channel tint in brand palette:
+        //   r → WB navy  #0C245E  →  (0.047, 0.141, 0.369)
+        //   g → PB teal  #1E6B8A  →  (0.118, 0.420, 0.533)
+        //   b → CB sage  #0B7261  →  (0.043, 0.447, 0.380)
+        vec3 waveR = vec3(0.047, 0.141, 0.369) * r;
+        vec3 waveG = vec3(0.118, 0.420, 0.533) * g;
+        vec3 waveB = vec3(0.043, 0.447, 0.380) * b;
+
+        gl_FragColor = vec4(bg + waveR + waveG + waveB, 1.0);
+      }
+    `;
+
+    const initScene = () => {
+      refs.scene = new THREE.Scene();
+      refs.renderer = new THREE.WebGLRenderer({ canvas, antialias: false });
+      refs.renderer.setPixelRatio(Math.min(window.devicePixelRatio, 2));
+      refs.renderer.setClearColor(new THREE.Color(0x080d18));
+
+      refs.camera = new THREE.OrthographicCamera(-1, 1, 1, -1, 0, -1);
+
+      refs.uniforms = {
+        resolution: { value: [canvas.clientWidth || window.innerWidth, canvas.clientHeight || window.innerHeight] },
+        time:       { value: 0.0 },
+        xScale:     { value: 1.1 },
+        yScale:     { value: 0.25 },
+        distortion: { value: 0.03 },
+      };
+
+      const positions = new THREE.BufferAttribute(
+        new Float32Array([
+          -1.0, -1.0, 0.0,
+           1.0, -1.0, 0.0,
+          -1.0,  1.0, 0.0,
+           1.0, -1.0, 0.0,
+          -1.0,  1.0, 0.0,
+           1.0,  1.0, 0.0,
+        ]),
+        3
+      );
+      const geometry = new THREE.BufferGeometry();
+      geometry.setAttribute("position", positions);
+
+      const material = new THREE.RawShaderMaterial({
+        vertexShader,
+        fragmentShader,
+        uniforms: refs.uniforms,
+        side: THREE.DoubleSide,
+      });
+
+      refs.mesh = new THREE.Mesh(geometry, material);
+      refs.scene.add(refs.mesh);
+
+      handleResize();
+    };
+
+    const animate = () => {
+      if (refs.uniforms) refs.uniforms.time.value += 0.005;
+      if (refs.renderer && refs.scene && refs.camera) {
+        refs.renderer.render(refs.scene, refs.camera);
+      }
+      refs.animationId = requestAnimationFrame(animate);
+    };
+
+    const handleResize = () => {
+      if (!refs.renderer || !refs.uniforms) return;
+      const w = canvas.clientWidth || window.innerWidth;
+      const h = canvas.clientHeight || window.innerHeight;
+      refs.renderer.setSize(w, h, false);
+      refs.uniforms.resolution.value = [w, h];
+    };
+
+    initScene();
+    animate();
+    window.addEventListener("resize", handleResize);
+
+    return () => {
+      if (refs.animationId) cancelAnimationFrame(refs.animationId);
+      window.removeEventListener("resize", handleResize);
+      if (refs.mesh) {
+        refs.scene?.remove(refs.mesh);
+        refs.mesh.geometry.dispose();
+        if (refs.mesh.material instanceof THREE.Material) {
+          refs.mesh.material.dispose();
+        }
+      }
+      refs.renderer?.dispose();
+    };
+  }, []);
+
+  return (
+    <canvas
+      ref={canvasRef}
+      className="absolute inset-0 w-full h-full block"
+    />
+  );
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,8 @@
         "react": "^18",
         "react-dom": "^18",
         "react-icons": "^4.11.0",
-        "react-intersection-observer": "^10.0.3"
+        "react-intersection-observer": "^10.0.3",
+        "three": "^0.183.2"
       },
       "devDependencies": {
         "autoprefixer": "^10.4.21",
@@ -4361,6 +4362,12 @@
         "node": ">=0.8"
       }
     },
+    "node_modules/three": {
+      "version": "0.183.2",
+      "resolved": "https://registry.npmjs.org/three/-/three-0.183.2.tgz",
+      "integrity": "sha512-di3BsL2FEQ1PA7Hcvn4fyJOlxRRgFYBpMTcyOgkwJIaDOdJMebEFPA+t98EvjuljDx4hNulAGwF6KIjtwI5jgQ==",
+      "license": "MIT"
+    },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
@@ -7771,6 +7778,11 @@
       "requires": {
         "thenify": ">= 3.1.0 < 4"
       }
+    },
+    "three": {
+      "version": "0.183.2",
+      "resolved": "https://registry.npmjs.org/three/-/three-0.183.2.tgz",
+      "integrity": "sha512-di3BsL2FEQ1PA7Hcvn4fyJOlxRRgFYBpMTcyOgkwJIaDOdJMebEFPA+t98EvjuljDx4hNulAGwF6KIjtwI5jgQ=="
     },
     "to-regex-range": {
       "version": "5.0.1",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "react": "^18",
     "react-dom": "^18",
     "react-icons": "^4.11.0",
-    "react-intersection-observer": "^10.0.3"
+    "react-intersection-observer": "^10.0.3",
+    "three": "^0.183.2"
   },
   "devDependencies": {
     "autoprefixer": "^10.4.21",


### PR DESCRIPTION
## Summary

- Replaces the flat `bg-surface` hero with a Three.js WebGL shader animation
- Brand-adapted fragment shader: dark navy base (`#080D18`) with three overlapping sine waves in WB navy, PB teal, and CB sage — subtle chromatic separation gives the waves an iridescent quality
- New `LiquidButton` component with glassmorphism shadow + SVG distortion filter for the hero CTAs
- Hero content wrapped in a double-border container for a clean editorial frame
- Product cards moved to a separate `bg-surface` section below with an `#products` anchor
- Improved text readability throughout (bumped white opacity across all small text elements)

## Test plan

- [ ] Homepage hero shows animated shader background with readable text
- [ ] "Explore the suite" button scrolls to product cards
- [ ] "Read our story" links to `/about`
- [ ] LiquidButton glass effect visible on both CTA buttons
- [ ] Product cards render correctly in the light section below
- [ ] No layout breakage on mobile
- [ ] Build passes (`npm run build`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)